### PR TITLE
fix syntax change, correct as of %zuse 415

### DIFF
--- a/tutorials/unit-testing/src/base/tests/app/pomodoro.hoon
+++ b/tutorials/unit-testing/src/base/tests/app/pomodoro.hoon
@@ -25,11 +25,10 @@
 ::  Test adding a watcher to the list.
 ::
 ++  test-add-client
-  =|  run=@ud 
+  =|  run=@ud
   =^  move  agent  (~(on-poke agent (bowl run)) %pomodoro-action !>([%add-client ~zod]))
   =+  !<(=state on-save:agent)
   %+  expect-eq
-    !>  [%0 watchers={~zod} status=%break]
-    !>  watchers.state
-  ==
+    !>  [%0 watchers=(sy ~[~zod]) status=%break]
+    !>  state
 --


### PR DESCRIPTION
The `{~zod}` set syntax doesn't work on my fakezod. This repo hasn't been updated for 2 years. However it is used as an example in [App School](https://developers.urbit.org/courses/asl). So I'm contributing this small fix.